### PR TITLE
Fix adding a diffspike reducing PP

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -81,7 +81,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         {
             double consistentTopStrain = difficulty / 10; // What would the top strain be if all strain values were identical
 
-            return objectStrains.Sum(s => Math.Pow(Math.Min(1, s / consistentTopStrain), 5));
+            // Apply a power to nerf diffspikes, but only apply that power if s / adjustedDifficulty is less than 1, to prevent buffing certain spiky maps
+            return objectStrains.Sum(s => s >= adjustedDifficulty ? s / adjustedDifficulty : Math.Pow(s / adjustedDifficulty, 8));
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -80,9 +80,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         public double CountDifficultStrains()
         {
             double consistentTopStrain = difficulty / 10; // What would the top strain be if all strain values were identical
-
-            // Apply a power to nerf diffspikes, but only apply that power if s / adjustedDifficulty is less than 1, to prevent buffing certain spiky maps
-            return objectStrains.Sum(s => s >= adjustedDifficulty ? s / adjustedDifficulty : Math.Pow(s / adjustedDifficulty, 8));
+            // Use a weighted sum of all strains. Constants are arbitrary and give nice values
+            return objectStrains.Sum(s => 1.3 / (1 + Math.Exp(-14.15 * (Math.Pow(s / consistentTopStrain, 2) - 0.945))));
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         {
             double consistentTopStrain = difficulty / 10; // What would the top strain be if all strain values were identical
             // Use a weighted sum of all strains. Constants are arbitrary and give nice values
-            return objectStrains.Sum(s => 1.3 / (1 + Math.Exp(-14.15 * (Math.Pow(s / consistentTopStrain, 2) - 0.945))));
+            return objectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -37,6 +37,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         protected virtual double DifficultyMultiplier => DEFAULT_DIFFICULTY_MULTIPLIER;
 
         protected List<double> objectStrains = new List<double>();
+        protected double difficulty;
 
         protected OsuStrainSkill(Mod[] mods)
             : base(mods)
@@ -45,7 +46,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public override double DifficultyValue()
         {
-            double difficulty = 0;
+            difficulty = 0;
             double weight = 1;
 
             // Sections with 0 strain are excluded to avoid worst-case time complexity of the following sort (e.g. /b/2351871).
@@ -78,9 +79,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         /// </summary>
         public double CountDifficultStrains()
         {
-            double topStrain = objectStrains.Max();
+            double consistentTopStrain = difficulty / 10; // What would the top strain be if all strain values were identical
 
-            return objectStrains.Sum(s => Math.Pow(s / topStrain, 4));
+            return objectStrains.Sum(s => Math.Pow(1, s / consistentTopStrain, 5));
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         {
             double consistentTopStrain = difficulty / 10; // What would the top strain be if all strain values were identical
 
-            return objectStrains.Sum(s => Math.Pow(1, s / consistentTopStrain, 5));
+            return objectStrains.Sum(s => Math.Pow(Math.Min(1, s / consistentTopStrain), 5));
         }
     }
 }


### PR DESCRIPTION
Uses the result of the geometric sum on strains to calculate `countDifficultStrains` instead of `topStrain`

**Problem:**
Consider two 'maps', where each map has one object per strain and is 100 strains long. 
The first map is entirely strain value of 1. This means it has a `difficulty` (in OsuStrainSkill) of 9.99965, and `countDifficultStrains` of 100. For a 1 miss play, it will have a `value` (in OsuPerformanceCalculator) of 3579.62, and 3998.51 for FC.
The second map is 99 strains of value 1 and 1 strain of value 1.5. It has a `difficulty` of 10.12467, however `countDifficultStrains` is reduced to 20.55. For a 1 miss play, it will have a `value` of 3514.54, less than the first map.
This is undeniably a flaw in the system - adding the higher difficulty strain makes the play harder, yet due to the structure of `countDifficultStrains` reduces the PP awarded.
This PR has no effect on the first map, leaving `value` at 3579.62.
The second map has `countDifficultStrains` of 94.05 instead of 20.55, which results in a `value` of 3710.81, (deservedly) higher than the first map, and lower than the value of the first map for full combo.
(these values are all outdated compared to the most recent version, but the same idea is followed)

**Actual Effects:**
This generally buffs diffspike heavy maps (inai sekai, packet hero, anoyo-iki buffed relative to current combo scaling removal) and very rarely nerfs maps compared to current combo scaling removal (would likely be some nerfing present due to higher power used for `countDifficultStrains`). Most consistency maps (uta) are left almost untouched.